### PR TITLE
Update index.js

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -120,7 +120,7 @@ export const fetchUser = () => async dispatch => {
 		  // Set token to Auth header
 		  setAuthToken(token);
 			const res = await axios.get("/api/user/current_user");
-			if (res.message) {
+			if (res.data.message) {
 				// An error will occur if the token is invalid.
 	      // If this happens, you may want to remove the invalid token.
 	      localStorage.removeItem("token")


### PR DESCRIPTION
setCurrentUser action creator was not correctly identifying http response for presence of error message, therefore proceeding to set the current user with a blank payload.